### PR TITLE
Making debug script cross platform

### DIFF
--- a/scripts/debug
+++ b/scripts/debug
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
-if [ $1 = "dev" ]; then
-  appname="Electron"
+if [[ $1 == "dev" ]]; then
+	appname="Electron"
 else
-  appname="Cerebro"
+	appname="Cerebro"
 fi
-symlink="${HOME}/Library/Application Support/${appname}/plugins/node_modules/${PWD##*/}"
+
+OS=$(uname -s)
+if [[ $OS == "Darwin" ]]; then
+	symlink="${HOME}/Library/Application Support/${appname}/plugins/node_modules/${PWD##*/}"
+elif [[ $OS == "Linux" ]]; then
+	symlink="${HOME}/.config/${appname}/plugins/node_modules/${PWD##*/}"
+elif [[ $OS == "WindowsNT" ]]; then
+	symlink="%appdata%\Cerebro\plugins\node_modules\\${PWD##*/}"
+else
+	echo "You may need to manually create a symlink for debugging"
+fi
+
 ln -s "${PWD}" "$symlink"
 trap "rm \"$symlink\"" SIGHUP SIGINT SIGTERM
 ./node_modules/.bin/webpack --watch


### PR DESCRIPTION
#1 

Unfortunately, I don't have access to a Windows machine at the moment, nor I am very familiar with it. I know that ${PWD##*/} will not execute correctly. 

I searched for a bit and could not find an elegant solution to extracting only the current folder name instead of the entire path. Maybe someone who is more savvy with Windows has a solution.