### PR TITLE
Add native (cmd.exe) windows support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,11 +21,16 @@ npm run debug
 ```
 
 
-> On windows use [cygwin](https://www.cygwin.com/) or [git bash](https://git-scm.com/download/win) instead of cmd.exe and `./scripts/debug` command insttead of `npm run debug`
+> On windows use [cygwin](https://www.cygwin.com/) or [git bash](https://git-scm.com/download/win) instead of cmd.exe and `./scripts/debug` command instead of `npm run debug`.
+If you choose to use cmd.exe, use `npm run debug:windows`
 
 Or if you running Cerebro from source code:
 ```
 npm run debug -- dev
+```
+Or in cmd.exe
+```
+npm run debug:windows dev
 ```
 
 ## Documentation

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "scripts": {
     "build": "webpack && babili dist -d dist --compact --no-comments",
     "debug": "./scripts/debug",
-    "prepublish": "rm -rf ./dist && npm run build"
+    "debug:windows": "scripts\\debug.bat",
+    "prepublish": "rimraf ./dist && npm run build"
   },
   "main": "dist/index.js",
   "keywords": [
@@ -31,6 +32,7 @@
     "cerebro-tools": "^0.1.0",
     "css-loader": "^0.26.0",
     "react": "^15.4.1",
+    "rimraf": "^2.6.1",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "2.1.0-beta.27"

--- a/scripts/debug.bat
+++ b/scripts/debug.bat
@@ -1,0 +1,14 @@
+@echo off
+IF "%1%"==""dev"" (
+  set appname=Electron
+) ELSE (
+  set appname=Cerebro
+)
+
+for %%* in (.) do set dirname=%%~nx*
+SET symlink=%APPDATA%\%appname%\plugins\node_modules\%dirname%
+
+echo "Creating symlink: %symlink% -> %cd%"
+
+mklink /d %symlink% %cd%
+start "" /b /wait node_modules\.bin\webpack --watch


### PR DESCRIPTION
Wrote this for people that wouldn't want to install Cygwin especially on Windows 10 that has the new bash support. It runs just like the bash version. Only issue is that terminating the job cannot be intercepted to delete the symlink. That is just a limitation on batch scripts, but it is still better than nothing