### PR TITLE
Improve Windows support

### DIFF
--- a/scripts/debug.bat
+++ b/scripts/debug.bat
@@ -6,9 +6,9 @@ IF "%1%"==""dev"" (
 )
 
 for %%* in (.) do set dirname=%%~nx*
-SET symlink=%APPDATA%\%appname%\plugins\node_modules\%dirname%
+SET symlink="%APPDATA%\%appname%\plugins\node_modules\%dirname%"
 
 echo "Creating symlink: %symlink% -> %cd%"
 
-mklink /d %symlink% %cd%
-start "" /b /wait node_modules\.bin\webpack --watch
+mklink /d %symlink% "%cd%"
+start "" /wait node_modules\.bin\webpack --watch


### PR DESCRIPTION
Webpack was still running in the background after killing the script
Also, directories with spaces were failing as well