### PR TITLE
Set package.json version as 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebro-plugin",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "",
   "license": "MIT",
   "repository": "KELiON/cerebro-plugin",


### PR DESCRIPTION
Since this is a boilerplate, it's expected to serve new plugins that would start at 1.0.0 version.